### PR TITLE
remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-veltiosoft.dev


### PR DESCRIPTION
## 概要

Cloudflare Pages では CNAME が不要のはずなので消す。

GitHub Pages からの移行のドキュメント（あんまそれっぽいこと言われていないが、特にいるとも言われていないので消す。
https://developers.cloudflare.com/pages/migrations/migrating-jekyll-from-github-pages/

### レビュー観点

- [x] デプロイ確認用URLに飛んで、正常にアクセスできるか
- [x] CNAME 消しても問題ないか

### Cloudflare Pages デプロイ確認用
- https://veltiosoft-dev.pages.dev/sink/tracker
- https://veltiosoft-dev.pages.dev/helloworld

## PR が LGTM されたらやること
- [x] github pages の停止
- [x] cloudflare pages の プロダクション ブランチを master に変更
- [x] cloudflare で veltiosoft.dev の DNS 設定を変更
- [x] merge